### PR TITLE
Custom Grafana Dashboard Variable Support

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -8,6 +8,7 @@ import { map } from 'lodash';
 export class DataSource extends DataSourceWithBackend<TrinoQuery, TrinoDataSourceOptions> {
   constructor(instanceSettings: DataSourceInstanceSettings<TrinoDataSourceOptions>) {
     super(instanceSettings);
+    this.variables = new TrinoDataVariableSupport();
     // give interpolateQueryStr access to this
     this.interpolateQueryStr = this.interpolateQueryStr.bind(this);
   }

--- a/src/variable.ts
+++ b/src/variable.ts
@@ -1,0 +1,12 @@
+import { StandardVariableQuery, StandardVariableSupport } from '@grafana/data';
+import { DataSource } from './datasource';
+import { TrinoQuery } from 'types';
+
+export class TrinoDataVariableSupport extends StandardVariableSupport<DataSource> {
+  toDataQuery(query: StandardVariableQuery): TrinoQuery {
+    return {
+      refId: 'TrinoDataSource-QueryVariable',
+      rawSQL: query.query,
+    };
+  }
+}


### PR DESCRIPTION
When select Trino plugin in Grafana while adding query variable. It was not showing a text area where user can put query.

Fixes #197