### PR TITLE
Add support for oauth2 client-credentials flow to query from trino.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -42,25 +43,63 @@ jobs:
           version: latest
           args: buildAll
 
-      - name: End to end test
+      - name: Setup services (Trino, Grafana, PostgreSQL, Keycloak)
         run: |
           docker network create trino
 
-          docker run \
-            --rm --detach \
+          echo "Starting PostgreSQL..."
+          docker run --rm --detach \
+            --name postgres \
+            --net trino \
+            --env POSTGRES_USER=keycloak \
+            --env POSTGRES_PASSWORD=keycloak \
+            --env POSTGRES_DB=keycloak \
+            postgres:17.4
+          
+          echo "Starting Keycloak..."
+          docker run --rm --detach \
+            --name keycloak \
+            --net trino \
+            --publish 18080:8080 \
+            --env KC_BOOTSTRAP_ADMIN_USERNAME=admin \
+            --env KC_BOOTSTRAP_ADMIN_PASSWORD=admin \
+            --env KC_DB=postgres \
+            --env KC_DB_URL_HOST=postgres \
+            --env KC_DB_URL_DATABASE=keycloak \
+            --env KC_DB_USERNAME=keycloak \
+            --env KC_DB_PASSWORD=keycloak \
+            --volume "$(pwd)/test-data/test-keycloak-realm.json:/opt/keycloak/data/import/realm.json" \
+            quay.io/keycloak/keycloak:26.1.4 \
+            start-dev --import-realm
+
+          echo "Waiting for Keycloak to be ready..."
+          while true; do
+            if curl -s http://localhost:18080/realms/master | grep -q "realm"; then
+              echo "Keycloak is ready!"
+             break
+           fi
+            echo "Waiting for Keycloak..."
+           sleep 5
+          done
+
+          echo "Starting Trino..."
+          docker run --rm --detach \
             --name trino \
             --net trino \
+            --volume "$(pwd)/test-data/test-trino-config.properties:/etc/trino/config.properties" \
             trinodb/trino:468
 
-          docker run \
-            --rm --detach \
+          echo "Starting Grafana..."
+          docker run --rm --detach \
             --name grafana \
             --net trino \
             --publish 3000:3000 \
             --volume "$(pwd):/var/lib/grafana/plugins/trino" \
             --env "GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=trino-datasource" \
-           grafana/grafana:11.4.0
+            grafana/grafana:11.4.0
 
-           npx tsc -p tsconfig.json --noEmit
-           npx playwright install
-           npx playwright test
+      - name: End to end test
+        run: |
+          npx tsc -p tsconfig.json --noEmit
+          npx playwright install
+          npx playwright test

--- a/pkg/trino/client/client.go
+++ b/pkg/trino/client/client.go
@@ -1,0 +1,85 @@
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"io"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+)
+
+var (
+	lock  = &sync.Mutex{}
+	token *Token
+)
+
+type Client struct {
+	*http.Client
+	ClientId          string
+	ClientSecret      string
+	Url               string
+	ImpersonationUser string
+}
+
+func (c *Client) Do(req *http.Request) (*http.Response, error) {
+	token, err := c.getToken()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token.AccessToken)
+	if c.ImpersonationUser != "" {
+		req.Header.Set("X-Trino-User", c.ImpersonationUser)
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) getToken() (*Token, error) {
+	if token != nil && !token.isAlmostExpired() {
+		return token, nil
+	}
+	lock.Lock()
+	defer lock.Unlock()
+	if token != nil && !token.isAlmostExpired() {
+		return token, nil
+	}
+	newToken, err := c.retrieveToken()
+	if err != nil {
+		return nil, err
+	}
+	token = newToken
+	return token, nil
+}
+
+func (c *Client) retrieveToken() (*Token, error) {
+	log.DefaultLogger.Debug("Try retrieve token")
+	values := url.Values{
+		"client_id":     []string{c.ClientId},
+		"client_secret": []string{c.ClientSecret},
+		"grant_type":    []string{"client_credentials"},
+	}
+
+	token := &Token{}
+	response, err := c.PostForm(c.Url, values)
+	if err != nil {
+		return nil, fmt.Errorf("failed to request the token response: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != 200 {
+		return nil, errors.New("Cannot obtain token from IDP. Status code=" + response.Status)
+	}
+	var jsonResponse []byte
+	if jsonResponse, err = io.ReadAll(response.Body); err != nil {
+		return nil, fmt.Errorf("failed to read the token response: %w", err)
+	}
+	err = json.Unmarshal(jsonResponse, token)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode the token response: %w", err)
+	}
+	token.ExpiresAt = time.Now().Add(time.Second * time.Duration(token.ExpiresIn))
+	log.DefaultLogger.Debug("Token will expire at:", "date", token.ExpiresAt.Format(time.RFC1123Z))
+	return token, nil
+}

--- a/pkg/trino/client/token.go
+++ b/pkg/trino/client/token.go
@@ -1,0 +1,26 @@
+package client
+
+import (
+	"time"
+)
+
+// UntilExpirationInSeconds time has to be a greater than HTTP request timeout
+// In most HTTP clients HTTP request timeout is 30 seconds.
+const UntilExpirationInSeconds = 60
+
+type Token struct {
+	AccessToken string `json:"access_token"`
+	ExpiresIn   int    `json:"expires_in"`
+	ExpiresAt   time.Time
+}
+
+func (token *Token) isAlmostExpired() bool {
+	if token.AccessToken == "" {
+		return true
+	} else {
+		if time.Now().Add(time.Second * time.Duration(UntilExpirationInSeconds)).After(token.ExpiresAt) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/trino/models/settings.go
+++ b/pkg/trino/models/settings.go
@@ -16,6 +16,10 @@ type TrinoDatasourceSettings struct {
 	Opts                httpclient.Options `json:"-"`
 	EnableImpersonation bool               `json:"enableImpersonation"`
 	AccessToken         string             `json:"accessToken"`
+	TokenUrl            string             `json:"tokenUrl"`
+	ClientId            string             `json:"clientId"`
+	ClientSecret        string             `json:"clientSecret"`
+	ImpersonationUser   string             `json:"impersonationUser"`
 }
 
 func (s *TrinoDatasourceSettings) Load(config backend.DataSourceInstanceSettings) error {
@@ -47,6 +51,9 @@ func (s *TrinoDatasourceSettings) Load(config backend.DataSourceInstanceSettings
 	}
 	if token, ok := config.DecryptedSecureJSONData["accessToken"]; ok {
 		s.AccessToken = token
+	}
+	if clientSecret, ok := config.DecryptedSecureJSONData["clientSecret"]; ok {
+		s.ClientSecret = clientSecret
 	}
 	return nil
 }

--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -1,5 +1,5 @@
 import React, { ChangeEvent, PureComponent } from 'react';
-import { DataSourceHttpSettings, InlineField, InlineSwitch, SecretInput } from '@grafana/ui';
+import { DataSourceHttpSettings, InlineField, InlineSwitch, SecretInput, Input } from '@grafana/ui';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import {TrinoDataSourceOptions, TrinoSecureJsonData} from './types';
 
@@ -18,6 +18,21 @@ export class ConfigEditor extends PureComponent<Props, State> {
     }
     const onResetToken = () => {
       onOptionsChange({...options, secureJsonFields: {...options.secureJsonFields, accessToken: false }, secureJsonData: {...options.secureJsonData, accessToken: '' }});
+    };
+    const onTokenUrlChange = (event: ChangeEvent<HTMLInputElement>) => {
+      onOptionsChange({...options, jsonData: {...options.jsonData, tokenUrl: event.target.value}})
+    };
+    const onClientIdChange = (event: ChangeEvent<HTMLInputElement>) => {
+      onOptionsChange({...options, jsonData: {...options.jsonData, clientId: event.target.value}})
+    };
+    const onClientSecretChange = (event: ChangeEvent<HTMLInputElement>) => {
+      onOptionsChange({...options, secureJsonData: {...options.secureJsonData, clientSecret: event.target.value}})
+    };
+    const onResetClientSecret = () => {
+      onOptionsChange({...options, secureJsonFields: {...options.secureJsonFields, clientSecret: false}, secureJsonData: {...options.secureJsonData, clientSecret: ''}});
+    };
+    const onImpersonationUserChange = (event: ChangeEvent<HTMLInputElement>) => {
+      onOptionsChange({...options, jsonData: {...options.jsonData, impersonationUser: event.target.value}})
     };
     return (
       <div className="gf-form-group">
@@ -55,6 +70,64 @@ export class ConfigEditor extends PureComponent<Props, State> {
                   width={40}
                   onReset={onResetToken}
                 />
+            </InlineField>
+          </div>
+        </div>
+
+        <h3 className="page-heading">OAuth Trino Authentication</h3>
+        <div className="gf-form-group">
+          <div className="gf-form-inline">
+            <InlineField
+              label="Token URL"
+              tooltip="If set, token is retrieved by client credentials flow before request to Trino is sent"
+              labelWidth={26}
+            >
+              <Input
+                value={options.jsonData?.tokenUrl ?? ''}
+                onChange={onTokenUrlChange}
+                width={60}
+              />
+            </InlineField>
+          </div>
+          <div className="gf-form-inline">
+            <InlineField
+              label="Client id"
+              tooltip="Required if Token URL is set"
+              labelWidth={26}
+            >
+              <Input
+                value={options.jsonData?.clientId ?? ''}
+                onChange={onClientIdChange}
+                width={60}
+              />
+            </InlineField>
+          </div>
+          <div className="gf-form-inline">
+            <InlineField
+              label="Client secret"
+              tooltip="Required if Token URL is set"
+              labelWidth={26}
+            >
+              <SecretInput
+                value={options.secureJsonData?.clientSecret ?? ''}
+                isConfigured={options.secureJsonFields?.clientSecret}
+                onChange={onClientSecretChange}
+                width={60}
+                onReset={onResetClientSecret}
+              />
+            </InlineField>
+          </div>
+          <div className="gf-form-inline">
+            <InlineField
+              label="Impersonation user"
+              tooltip="If set, this user will be used for impersonation in Trino"
+              labelWidth={26}
+            >
+              <Input
+                value={options.jsonData?.impersonationUser ?? ''}
+                onChange={onImpersonationUserChange}
+                width={60}
+              />
             </InlineField>
           </div>
         </div>

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -1,28 +1,78 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 
-test('test', async ({ page }) => {
-  await page.goto('http://localhost:3000/login');
-  await page.getByTestId('data-testid Username input field').fill('admin');
-  await page.getByTestId('data-testid Password input field').fill('admin');
-  await page.getByTestId('data-testid Login button').click();
-  await page.getByTestId('data-testid Skip change password button').click();
-  await page.getByTestId('data-testid Toggle menu').click();
-  await page.getByRole('link', { name: 'Connections' }).click();
-  await page.getByRole('link', { name: 'Trino' }).click();
-  await page.locator('.css-1yhi3xa').click();
-  await page.getByRole('button', { name: 'Add new data source' }).click();
-  await page.getByTestId('data-testid Datasource HTTP settings url').fill('http://trino:8080');
-  await page.locator('div').filter({ hasText: /^Impersonate logged in userAccess token$/ }).getByLabel('Toggle switch').click();
-  await page.locator('input[type="password"]').fill('aaa');
-  await page.getByTestId('data-testid Data source settings page Save and Test button').click();
-  await page.getByLabel('Explore data').click();
-  await page.getByTestId('data-testid TimePicker Open Button').click();
-  await page.getByTestId('data-testid Time Range from field').fill('1995-01-01');
-  await page.getByTestId('data-testid Time Range to field').fill('1995-12-31');
-  await page.getByTestId('data-testid TimePicker submit button').click();
-  await page.locator('div').filter({ hasText: /^Format asChoose$/ }).locator('svg').click();
-  await page.getByRole('option', { name: 'Table' }).click();
-  await page.getByTestId('data-testid Code editor container').click();
-  await page.getByTestId('data-testid RefreshPicker run button').click();
-  await expect(page.getByTestId('data-testid table body')).toContainText(/.*1995-01-19 0.:00:005703857F.*/);
+const GRAFANA_CLIENT = 'grafana-client';
+const EXPORT_DATA = 'Explore data';
+
+async function login(page: Page) {
+    await page.goto('http://localhost:3000/login');
+    await page.getByTestId('data-testid Username input field').fill('admin');
+    await page.getByTestId('data-testid Password input field').fill('admin');
+    await page.getByTestId('data-testid Login button').click();
+    await page.getByTestId('data-testid Skip change password button').click();
+}
+
+async function goToTrinoSettings(page: Page) {
+    await page.getByTestId('data-testid Toggle menu').click();
+    await page.getByRole('link', {name: 'Connections'}).click();
+    await page.getByRole('link', {name: 'Trino'}).click();
+    await page.locator('.css-1yhi3xa').click();
+    await page.getByRole('button', {name: 'Add new data source'}).click();
+}
+
+async function setupDataSourceWithAccessToken(page: Page) {
+    await page.getByTestId('data-testid Datasource HTTP settings url').fill('http://trino:8080');
+    await page.locator('div').filter({hasText: /^Impersonate logged in userAccess token$/}).getByLabel('Toggle switch').click();
+    await page.locator('div').filter({hasText: /^Access token$/}).locator('input[type="password"]').fill('aaa');
+    await page.getByTestId('data-testid Data source settings page Save and Test button').click();
+}
+
+async function setupDataSourceWithClientCredentials(page: Page, clientId: string) {
+    await page.getByTestId('data-testid Datasource HTTP settings url').fill('http://trino:8080');
+    await page.locator('div').filter({hasText: /^Token URL$/}).locator('input').fill('http://keycloak:8080/realms/trino-realm/protocol/openid-connect/token');
+    await page.locator('div').filter({hasText: /^Client id$/}).locator('input').fill(clientId);
+    await page.locator('div').filter({hasText: /^Client secret$/}).locator('input[type="password"]').fill('grafana-secret');
+    await page.locator('div').filter({hasText: /^Impersonation user$/}).locator('input').fill('service-account-grafana-client');
+    await page.getByTestId('data-testid Data source settings page Save and Test button').click();
+}
+
+async function runQueryAndCheckResults(page: Page) {
+    await page.getByLabel(EXPORT_DATA).click();
+    await page.getByTestId('data-testid TimePicker Open Button').click();
+    await page.getByTestId('data-testid Time Range from field').fill('1995-01-01');
+    await page.getByTestId('data-testid Time Range to field').fill('1995-12-31');
+    await page.getByTestId('data-testid TimePicker submit button').click();
+    await page.locator('div').filter({hasText: /^Format asChoose$/}).locator('svg').click();
+    await page.getByRole('option', {name: 'Table'}).click();
+    await page.getByTestId('data-testid Code editor container').click();
+    await page.getByTestId('data-testid RefreshPicker run button').click();
+    await expect(page.getByTestId('data-testid table body')).toContainText(/.*1995-01-19 0.:00:005703857F.*/);
+}
+
+test('test with access token', async ({ page }) => {
+    await login(page);
+    await goToTrinoSettings(page);
+    await setupDataSourceWithAccessToken(page);
+    await runQueryAndCheckResults(page);
+});
+
+test('test client credentials flow', async ({ page }) => {
+    await login(page);
+    await goToTrinoSettings(page);
+    await setupDataSourceWithClientCredentials(page, GRAFANA_CLIENT);
+    await runQueryAndCheckResults(page);
+});
+
+test('test client credentials flow with wrong credentials', async ({ page }) => {
+    await login(page);
+    await goToTrinoSettings(page);
+    await setupDataSourceWithClientCredentials(page, "some-wrong-client");
+    await expect(page.getByLabel(EXPORT_DATA)).toHaveCount(0);
+});
+
+test('test client credentials flow with configured access token', async ({ page }) => {
+    await login(page);
+    await goToTrinoSettings(page);
+    await page.locator('div').filter({hasText: /^Access token$/}).locator('input[type="password"]').fill('aaa');
+    await setupDataSourceWithClientCredentials(page, GRAFANA_CLIENT);
+    await expect(page.getByLabel(EXPORT_DATA)).toHaveCount(0);
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,10 +48,14 @@ ORDER BY
 
 export interface TrinoSecureJsonData {
   accessToken?: string;
+  clientSecret?: string;
 }
 
 export interface TrinoDataSourceOptions extends DataSourceJsonData {
   enableImpersonation?: boolean;
+  tokenUrl?: string;
+  clientId?: string;
+  impersonationUser?: string
 }
 /**
  * Value that is used in the backend, but never sent over HTTP to the frontend

--- a/test-data/test-keycloak-realm.json
+++ b/test-data/test-keycloak-realm.json
@@ -1,0 +1,18 @@
+{
+  "id": "trino-realm",
+  "realm": "trino-realm",
+  "enabled": true,
+  "clients": [
+    {
+      "clientId": "grafana-client",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "grafana-secret",
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "protocol": "openid-connect",
+      "fullScopeAllowed": true
+    }
+  ]
+}

--- a/test-data/test-trino-config.properties
+++ b/test-data/test-trino-config.properties
@@ -1,0 +1,9 @@
+coordinator=true
+node-scheduler.include-coordinator=true
+http-server.http.port=8080
+discovery.uri=http://localhost:8080
+catalog.management=${ENV:CATALOG_MANAGEMENT}
+internal-communication.shared-secret=supersecretkey
+http-server.authentication.type=JWT
+http-server.authentication.jwt.key-file=http://keycloak:8080/realms/trino-realm/protocol/openid-connect/certs
+http-server.authentication.jwt.principal-field=preferred_username


### PR DESCRIPTION
Currently if you work with trino you have to specify token which has expiration. No way to refresh token automatically.
The better way is to use oauth2 client-credentials flow. For that we need to specify url where to get token and credentials for client (client id and client secret).
Token for client must be refreshed every time when it is almost expired (1 minute before expiration).
For some identity providers (like keycloak) we need a way to impersonate a user. 