### PR TITLE
fix variables interpolations

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -50,9 +50,11 @@ export class DataSource extends DataSourceWithBackend<TrinoQuery, TrinoDataSourc
     );
   }
 
-  applyTemplateVariables(query: TrinoQuery, scopedVars: ScopedVars): Record<string, any> {
-    query.rawSQL = getTemplateSrv().replace(query.rawSQL, scopedVars, this.interpolateQueryStr);
-    return query;
+  applyTemplateVariables(query: TrinoQuery, scopedVars: ScopedVars) {
+    return {
+      ...query,
+      rawSQL: getTemplateSrv().replace(query.rawSQL, scopedVars, this.interpolateQueryStr),
+    };
   }
 
   interpolateQueryStr(value: any, variable: { multi: any; includeAll: any }, defaultFormatFn: any) {


### PR DESCRIPTION
This pull request fixes https://github.com/trinodb/grafana-trino/issues/271

Previously, applyTemplateVariables directly modified the query object by assigning to query.rawSQL, causing unintended side effects due to object mutation. This update returns a new object instead, preserving immutability.