### PR TITLE
Add support for passing header X-Trino-Client-Tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ docker run -d -p 3000:3000 \
   * OAuth
 * Raw SQL editor only, no query builder yet
 * Macros
+* Client tags support, used to identify resource groups.
 
 ## Macros support
 

--- a/pkg/trino/datasource-context.go
+++ b/pkg/trino/datasource-context.go
@@ -12,9 +12,10 @@ import (
 )
 
 const (
-	accessTokenKey  = "accessToken"
-	trinoUserHeader = "X-Trino-User"
-	bearerPrefix    = "Bearer "
+	accessTokenKey     = "accessToken"
+	trinoUserHeader    = "X-Trino-User"
+	trinoClientTagsKey = "X-Trino-Client-Tags"
+	bearerPrefix       = "Bearer "
 )
 
 type SQLDatasourceWithTrinoUserContext struct {
@@ -38,6 +39,10 @@ func (ds *SQLDatasourceWithTrinoUserContext) QueryData(ctx context.Context, req 
 		}
 
 		ctx = context.WithValue(ctx, trinoUserHeader, user)
+	}
+
+	if settings.ClientTags != "" {
+		ctx = context.WithValue(ctx, trinoClientTagsKey, settings.ClientTags)
 	}
 
 	return ds.SQLDatasource.QueryData(ctx, req)

--- a/pkg/trino/datasource.go
+++ b/pkg/trino/datasource.go
@@ -83,6 +83,7 @@ func (s *TrinoDatasource) SetQueryArgs(ctx context.Context, headers http.Header)
 
 	user := ctx.Value(trinoUserHeader)
 	accessToken := ctx.Value(accessTokenKey)
+	clientTags := ctx.Value(trinoClientTagsKey)
 
 	if user != nil {
 		args = append(args, sql.Named(trinoUserHeader, string(user.(*backend.User).Login)))
@@ -90,6 +91,10 @@ func (s *TrinoDatasource) SetQueryArgs(ctx context.Context, headers http.Header)
 
 	if accessToken != nil {
 		args = append(args, sql.Named(accessTokenKey, accessToken.(string)))
+	}
+
+	if clientTags != nil {
+		args = append(args, sql.Named(trinoClientTagsKey, clientTags.(string)))
 	}
 
 	return args

--- a/pkg/trino/models/settings.go
+++ b/pkg/trino/models/settings.go
@@ -20,6 +20,7 @@ type TrinoDatasourceSettings struct {
 	ClientId            string             `json:"clientId"`
 	ClientSecret        string             `json:"clientSecret"`
 	ImpersonationUser   string             `json:"impersonationUser"`
+	ClientTags          string             `json:"clientTags"`
 }
 
 func (s *TrinoDatasourceSettings) Load(config backend.DataSourceInstanceSettings) error {

--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -34,6 +34,9 @@ export class ConfigEditor extends PureComponent<Props, State> {
     const onImpersonationUserChange = (event: ChangeEvent<HTMLInputElement>) => {
       onOptionsChange({...options, jsonData: {...options.jsonData, impersonationUser: event.target.value}})
     };
+    const onClientTagsChange = (event: ChangeEvent<HTMLInputElement>) => {
+      onOptionsChange({...options, jsonData: {...options.jsonData, clientTags: event.target.value}})
+    };
     return (
       <div className="gf-form-group">
         <DataSourceHttpSettings
@@ -70,6 +73,20 @@ export class ConfigEditor extends PureComponent<Props, State> {
                   width={40}
                   onReset={onResetToken}
                 />
+            </InlineField>
+          </div>
+          <div className="gf-form-inline">
+            <InlineField
+              label="Client Tags"
+              tooltip="A comma-separated list of strings, used to identify Trino resource groups."
+              labelWidth={26}
+            >
+              <Input
+                value={options.jsonData?.clientTags ?? ''}
+                onChange={onClientTagsChange}
+                width={60}
+                placeholder="tag1,tag2,tag3"
+              />
             </InlineField>
           </div>
         </div>

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -21,7 +21,7 @@ async function goToTrinoSettings(page: Page) {
 
 async function setupDataSourceWithAccessToken(page: Page) {
     await page.getByTestId('data-testid Datasource HTTP settings url').fill('http://trino:8080');
-    await page.locator('div').filter({hasText: /^Impersonate logged in userAccess token$/}).getByLabel('Toggle switch').click();
+    await page.locator('div').filter({hasText: /^Impersonate logged in user$/}).getByLabel('Toggle switch').click();
     await page.locator('div').filter({hasText: /^Access token$/}).locator('input[type="password"]').fill('aaa');
     await page.getByTestId('data-testid Data source settings page Save and Test button').click();
 }
@@ -32,6 +32,14 @@ async function setupDataSourceWithClientCredentials(page: Page, clientId: string
     await page.locator('div').filter({hasText: /^Client id$/}).locator('input').fill(clientId);
     await page.locator('div').filter({hasText: /^Client secret$/}).locator('input[type="password"]').fill('grafana-secret');
     await page.locator('div').filter({hasText: /^Impersonation user$/}).locator('input').fill('service-account-grafana-client');
+    await page.getByTestId('data-testid Data source settings page Save and Test button').click();
+}
+
+async function setupDataSourceWithClientTags(page: Page, clientTags: string) {
+    await page.getByTestId('data-testid Datasource HTTP settings url').fill('http://trino:8080');
+    await page.locator('div').filter({hasText: /^Impersonate logged in user$/}).getByLabel('Toggle switch').click();
+    await page.locator('div').filter({hasText: /^Access token$/}).locator('input[type="password"]').fill('aaa');
+    await page.locator('div').filter({hasText: /^Client Tags$/}).locator('input').fill(clientTags);
     await page.getByTestId('data-testid Data source settings page Save and Test button').click();
 }
 
@@ -75,4 +83,11 @@ test('test client credentials flow with configured access token', async ({ page 
     await page.locator('div').filter({hasText: /^Access token$/}).locator('input[type="password"]').fill('aaa');
     await setupDataSourceWithClientCredentials(page, GRAFANA_CLIENT);
     await expect(page.getByLabel(EXPORT_DATA)).toHaveCount(0);
+});
+
+test('test with client tags', async ({ page }) => {
+    await login(page);
+    await goToTrinoSettings(page);
+    await setupDataSourceWithClientTags(page, 'tag1,tag2,tag3');
+    await runQueryAndCheckResults(page);
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,7 +55,8 @@ export interface TrinoDataSourceOptions extends DataSourceJsonData {
   enableImpersonation?: boolean;
   tokenUrl?: string;
   clientId?: string;
-  impersonationUser?: string
+  impersonationUser?: string;
+  clientTags?: string;
 }
 /**
  * Value that is used in the backend, but never sent over HTTP to the frontend


### PR DESCRIPTION
# Add support for X-Trino-Client-Tags header

## Description

This PR adds support for the `X-Trino-Client-Tags` header in the Grafana Trino datasource plugin. The `X-Trino-Client-Tags` header is part of the official Trino client protocol and allows sending a comma-separated list of tag strings to identify Trino resource groups, which is useful for resource management and query monitoring.

## How to Use

1. Navigate to the Trino datasource configuration page in Grafana
2. In the "Trino" section, find the "Client tags" field
3. Enter a comma-separated list of tags (e.g., `grafana,dashboard,analytics`)
4. Save the configuration

The tags will be automatically sent with every query to help Trino administrators identify and manage resource usage from different client sources.

## Technical Details

- The `X-Trino-Client-Tags` header is only sent when client tags are configured (optional field)
- Tags are stored as a comma-separated string in the datasource configuration
- No breaking changes - existing configurations will continue to work unchanged

## Testing

- [x] Go backend builds successfully
- [x] Frontend TypeScript compiles without errors
- [x] All existing functionality remains intact
- [x] New feature is optional and doesn't affect existing setups

## References

- [Trino Client Protocol Documentation](https://trino.io/docs/current/develop/client-protocol.html#client-request-headers)
- [Trino Resource Groups Documentation](https://trino.io/docs/current/admin/resource-groups.html)
