### PR TITLE
Create a fresh datasource object per plugin instance

### DIFF
--- a/pkg/main.go
+++ b/pkg/main.go
@@ -20,10 +20,12 @@ func main() {
 	// from Grafana to create different instances of TrinoDatasource (per datasource
 	// ID). When datasource configuration changed Dispose method will be called and
 	// new datasource instance created using New factory.
-	s := &trino.TrinoDatasource{}
-	ds := trino.NewDatasource(s)
-	ds.Completable = s
+	// Build a fresh datasource object per instance so that disposing a
+	// replaced instance never tears down its successor's connections.
 	dsInstanceFactory := func(ctx context.Context, settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+		s := &trino.TrinoDatasource{}
+		ds := trino.NewDatasource(s)
+		ds.Completable = s
 		return ds.NewDatasource(ctx, settings)
 	}
 	if err := datasource.Manage("trino-datasource", dsInstanceFactory, datasource.ManageOpts{}); err != nil {


### PR DESCRIPTION
Fixes #347.

The instance factory returned one shared datasource object for every instance. On any datasource settings update, the SDK disposes the old instance 5 seconds after creating its replacement; because old and new were the same object, that delayed Dispose closed and cleared the connection cache the new instance had just populated, leaving every query and health check failing with `unable to get default db connection` until the plugin process restarted.

Building a fresh object per instance scopes disposal to the old instance's own connections. It also stops `TrinoDatasource.db` (used by the `Completable` implementation) from being shared across all configured Trino datasources.

Verified against a live Grafana 11.5.0: the reproduction in #347 (no-op datasource save, query, wait 5+ seconds, query again) no longer fails with this change.